### PR TITLE
Relax version bounds to support GHC 8.2.1

### DIFF
--- a/lzma.cabal
+++ b/lzma.cabal
@@ -44,7 +44,7 @@ library
   exposed-modules:     Codec.Compression.Lzma
   other-modules:       LibLzma
 
-  build-depends:       base       >=4.5    && <4.10
+  build-depends:       base       >=4.5    && <4.11
                      , bytestring >=0.9.2  && <0.11
 
   if os(windows)
@@ -70,10 +70,10 @@ test-suite lzma-tests
                      , base
                      , bytestring
   -- additional dependencies that require version bounds
-  build-depends:       HUnit                      >= 1.2      && <1.4
-                     , QuickCheck                 >= 2.8      && <2.9
+  build-depends:       HUnit                      >= 1.2      && <1.7
+                     , QuickCheck                 >= 2.8      && <2.11
                      , tasty                      >= 0.10     && <0.12
                      , tasty-hunit                == 0.9.*
-                     , tasty-quickcheck           >= 0.8.3.2  && < 0.9
+                     , tasty-quickcheck           >= 0.8.3.2  && < 0.10
 
   ghc-options:         -Wall -threaded


### PR DESCRIPTION
I've confirmed locally that the tests passed.